### PR TITLE
Re-arrange front page styles

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,44 +1,53 @@
-<div class="container h-full mx-auto flex justify-center items-center">
-	<div class="space-y-5 pt-5">
+<div class="container h-full ml-32 flex items-center">
+	<div class="space-y-5 pt-5 w-full md:w-2/3">
 		<h1 class="h1">Slocan Helps</h1>
 
-		<h3 class="h3">
-			Shared Resources for Communities affected by the Slocan Lake & Kootenay Lake Wildfires
-		</h3>
+		<p class="text-2xl">
+			Shared resources for communities affected by the <span class="font-bold"
+				>Slocan Lake & Kootenay Lake Wildfires</span
+			>
+		</p>
+
+		<p>
+			If you've been evacuated, are under alert, or are looking for information about the wildfires,
+			please start by accessing the <a class="underline text-primary-500" href="/resources"
+				>Provincial and District Resources</a
+			> as they are the most up-to-date and comprehensive sources of information.
+		</p>
+
+		<div class="flex justify-around">
+			<div class="w-full md:w-2/5 p-8 bg-secondary-300 text-zinc-800">
+				<div class="text-center text-xl">I'm an evacuee looking for help</div>
+
+				<div class="mt-8 text-center">
+					<a href="/offers" class="btn variant-filled-primary">View Offers of Help</a>
+				</div>
+			</div>
+
+			<div class="w-full md:w-2/5 p-8 bg-secondary-300 text-zinc-800">
+				<div class="text-center text-xl">I'd like to help</div>
+
+				<div class="mt-8 text-center">
+					<a href="/offers" class="btn variant-filled-primary">Offer Your Help</a>
+				</div>
+			</div>
+		</div>
 
 		<p>
 			This is a community-led site to care for our friends and neighbours during these difficult
 			times. We're just starting to build this resource, so please bear with us and please <a
-				class="btn-sm variant-ghost-secondary"
+				class="underline text-primary-500"
 				href="/contribute">contribute</a
 			> if you're able.
 		</p>
 
 		<p>
-			If you've been evacuated, are under alert, or are looking for information about the wildfires,
-			please start by accessing the <a class="btn variant-ghost-primary" href="/resources"
-				>Provincial and District Resources</a
-			> as they are the most up-to-date and comprehensive sources of information.
-		</p>
-
-		<p>
-			If you're an evacuee looking for help, you can <a
-				href="/offers"
-				class="btn variant-ghost-primary">View Offers of Help</a
-			>.
-		</p>
-
-		<p>
-			If you have something to offer evacuees, you can <a
-				href="https://slocan.getgrist.com/forms/qhosjjXEfVpTGCTrVacWne/25"
-				class="btn variant-ghost-primary">Offer Your Help</a
-			>.
-		</p>
-
-		<p>
 			We'll try to add more resources and information as we can. If you have any questions or need
 			help, please contact Blaine <a href="mailto:romeda@gmail.com">by email</a> at romeda dot gmail
-			dot com or <a href="https://www.facebook.com/romeda">via Facebook Messenger</a>.
+			dot com or
+			<a class="underline text-primary-500" href="https://www.facebook.com/romeda"
+				>via Facebook Messenger</a
+			>.
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
Tried to pull the text a little closer together and emphasize the "get help/offer help" buttons. Also turned some of the buttons into regular links, with some very prominent link styling.

Desktop:
<img width="1629" alt="image" src="https://github.com/user-attachments/assets/c46f2a7e-9cb9-4d78-ae9e-641c86c885a6">

Mobile:
<img width="1629" alt="image" src="https://github.com/user-attachments/assets/81b798f2-36aa-4383-927f-37684f65238c">

Let me know if revisions are needed!